### PR TITLE
Add configurable top_n limit across CLI and web dashboards

### DIFF
--- a/AI/ML/web_interface/templates/analyze.html
+++ b/AI/ML/web_interface/templates/analyze.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f5b13379c0c092b4f9167231f21b101bec9ffc1e0f0dee8527f9ed4d31ef1e5
-size 15571
+oid sha256:ad9c1565bb5e2338a4b12e8498f896cabe8853dccd13ce797024f153ea81f799
+size 5329


### PR DESCRIPTION
## Summary
- add a configurable `top_n` parameter to results dashboards so the limit is tracked in metadata and applied consistently
- expose a `--top-n` option in the CLI and propagate it through file/database analysis and dashboard generation
- surface the same top-N control in the web workflow, persisting the selection through analysis and dashboard APIs

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68d73c4ceadc8323a36cc479ae0a71c2