### PR TITLE
Add Spearman correlation distribution visualization

### DIFF
--- a/AI/ML/visualization/results_dashboard.py
+++ b/AI/ML/visualization/results_dashboard.py
@@ -103,7 +103,11 @@ class ResultsDashboard:
             # Scatter plot
             scatter_chart = self.chart_generator.create_scatter_plot(data, analysis_results)
             visualizations['scatter'] = scatter_chart
-            
+
+            if 'rho_spearman' in data.columns:
+                rho_chart = self.chart_generator.create_rho_spearman_boxplot(data)
+                visualizations['rho_spearman'] = rho_chart
+
             # Clustering visualization
             clustering_chart = self.chart_generator.create_clustering_viz(analysis_results)
             visualizations['clustering'] = clustering_chart
@@ -222,6 +226,11 @@ class ResultsDashboard:
                     <h3>Gene Pair Correlation</h3>
                     <div id="scatter-chart"></div>
                 </div>
+
+                <div class="chart-container">
+                    <h3>Spearman Correlation Distribution</h3>
+                    <div id="rho-spearman-chart"></div>
+                </div>
             </div>
 
             <div id="gene-detail-modal" class="modal fade" tabindex="-1" aria-labelledby="geneDetailModalLabel" aria-hidden="true">
@@ -270,6 +279,7 @@ class ResultsDashboard:
                 // Embed Plotly charts
                 const boxplotData = {json.dumps(dashboard['visualizations'].get('boxplot', {}))};
                 const scatterData = {json.dumps(dashboard['visualizations'].get('scatter', {}))};
+                const rhoSpearmanData = {json.dumps(dashboard['visualizations'].get('rho_spearman', {}))};
 
                 if (boxplotData.data) {{
                     Plotly.newPlot('boxplot-chart', boxplotData.data, boxplotData.layout);
@@ -277,6 +287,10 @@ class ResultsDashboard:
 
                 if (scatterData.data) {{
                     Plotly.newPlot('scatter-chart', scatterData.data, scatterData.layout);
+                }}
+
+                if (rhoSpearmanData.data) {{
+                    Plotly.newPlot('rho-spearman-chart', rhoSpearmanData.data, rhoSpearmanData.layout);
                 }}
 
                 function getRecommendations() {{

--- a/AI/ML/web_interface/app.py
+++ b/AI/ML/web_interface/app.py
@@ -476,6 +476,8 @@ def get_visualization(session_id, chart_type):
             chart = chart_gen.create_boxplot(data, results)
         elif chart_type == 'scatter':
             chart = chart_gen.create_scatter_plot(data, results)
+        elif chart_type == 'rho_spearman_distribution':
+            chart = chart_gen.create_rho_spearman_boxplot(data, results)
         elif chart_type == 'clustering':
             chart = chart_gen.create_clustering_viz(results)
         elif chart_type == 'ranking':

--- a/AI/ML/web_interface/templates/results.html
+++ b/AI/ML/web_interface/templates/results.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6655f337324a3a99011d451bda25520e7b1a5da67b1382a0c94e873c7c99da0e
-size 23172
+oid sha256:d671d77e0be5b3bd50fdf6f74b74e3c587983422826ee013ae49e7bfc3cd20db
+size 8858

--- a/AI/ML/web_interface/visualization/results_dashboard.py
+++ b/AI/ML/web_interface/visualization/results_dashboard.py
@@ -103,7 +103,11 @@ class ResultsDashboard:
             # Scatter plot
             scatter_chart = self.chart_generator.create_scatter_plot(data, analysis_results)
             visualizations['scatter'] = scatter_chart
-            
+
+            if 'rho_spearman' in data.columns:
+                rho_chart = self.chart_generator.create_rho_spearman_boxplot(data, analysis_results)
+                visualizations['rho_spearman'] = json.loads(rho_chart)
+
             # Clustering visualization
             clustering_chart = self.chart_generator.create_clustering_viz(analysis_results)
             visualizations['clustering'] = clustering_chart
@@ -219,19 +223,29 @@ class ResultsDashboard:
                     <h3>Gene Pair Correlation</h3>
                     <div id="scatter-chart"></div>
                 </div>
+
+                <div class="chart-container">
+                    <h3>Spearman Correlation Distribution</h3>
+                    <div id="rho-spearman-chart"></div>
+                </div>
             </div>
-            
+
             <script>
                 // Embed Plotly charts
                 const boxplotData = {json.dumps(dashboard['visualizations'].get('boxplot', {}))};
                 const scatterData = {json.dumps(dashboard['visualizations'].get('scatter', {}))};
-                
+                const rhoSpearmanData = {json.dumps(dashboard['visualizations'].get('rho_spearman', {}))};
+
                 if (boxplotData.data) {{
                     Plotly.newPlot('boxplot-chart', boxplotData.data, boxplotData.layout);
                 }}
-                
+
                 if (scatterData.data) {{
                     Plotly.newPlot('scatter-chart', scatterData.data, scatterData.layout);
+                }}
+
+                if (rhoSpearmanData.data) {{
+                    Plotly.newPlot('rho-spearman-chart', rhoSpearmanData.data, rhoSpearmanData.layout);
                 }}
             </script>
         </body>


### PR DESCRIPTION
## Summary
- add a database helper to fetch rho_spearman distributions for a gene pair with optional limiting
- build a reusable Plotly violin/box chart for rho_spearman values and surface it across CLI and web dashboards
- expose the new Spearman chart in the Flask UI, HTML report generation, and refreshed results template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68d73d9525b48323aa7b5d53a44bbf23